### PR TITLE
Beta key environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Below are the available environment variables you may use to configure this Dock
 * **MKV_UID** The user ID of the `mkv` user inside the container.
 * **NO_EJECT** Disables ejecting the disc if set to "true".
 * **UMASK** The umask to create directories and MKV files with.
+* **BETA_KEY** The beta key used to extend the beta trial. Can be found here: https://www.makemkv.com/forum2/viewtopic.php?f=5&t=1053
 
 By default **DEVNAME** is automatically detected. If you use the Docker `--privileged` flag (not needed nor recommended)
 and have more than one optical device on your system this automated detection may not work. In these cases you'd want to

--- a/bin/rip.sh
+++ b/bin/rip.sh
@@ -9,6 +9,14 @@ set -e  # Exit script if a command fails.
 set -u  # Treat unset variables as errors and exit immediately.
 set -o pipefail  # Exit script if pipes fail instead of just the last program.
 
+# Add latest beta key.
+KEY=${BETA_KEY:-};
+if [ -n "$KEY" ]; then
+    sed -i "/app_Key/ d" /home/mkv/.MakeMKV/settings.conf
+    echo -e "\nINFO: Adding new beta key.\n"
+    echo "app_Key = \"$KEY\"" >> /home/mkv/.MakeMKV/settings.conf
+fi
+
 # Source function library.
 source /env.sh
 hook post-env


### PR DESCRIPTION
Throwing this in as another option. Instead of dynamically going and pulling the beta key, we could allow the user to pass BETA_KEY in as an environment variable.

I built an image and tested adding `-e BETA_KEY="T-rTYSOM9ktvR0Fihn9_2zbORtGKYXUsMtMoraj2fy_wXlDPrx6EX6Xk56opCsOK9bJl"` to my docker run command. I then did a docker exec into the container and did a cat on /home/mkv/.MakeMKV/setting.conf, the app_key was there and looked to be in the correct format.